### PR TITLE
Switch noImplicitAny back on

### DIFF
--- a/functions/@types/README.md
+++ b/functions/@types/README.md
@@ -1,0 +1,7 @@
+This the folder where we put custom type declaration files for libraries that don't come with one.
+
+File structure must be the same as in `node_modules`:
+- folders in this folder must be named with the name of the library (if the library is scoped then there must be a folder tree match the scope, e.g. `@google/firebase` gives a `@google` folder with a `firebase` folder inside)
+- each library folder must contain a file named `index.d.ts` with the root declaration file
+
+Please document how the types when determined. There is no need to type more than we need.

--- a/functions/@types/README.md
+++ b/functions/@types/README.md
@@ -1,7 +1,7 @@
 This the folder where we put custom type declaration files for libraries that don't come with one.
 
 File structure must be the same as in `node_modules`:
-- folders in this folder must be named with the name of the library (if the library is scoped then there must be a folder tree match the scope, e.g. `@google/firebase` gives a `@google` folder with a `firebase` folder inside)
+- folders in this folder must be named with the name of the library (if the library is scoped then there must be a folder tree that matches the scope, e.g. `@google/firebase` gives a `@google` folder with a `firebase` folder inside)
 - each library folder must contain a file named `index.d.ts` with the root declaration file
 
-Please document how the types when determined. There is no need to type more than we need.
+Please document how the types were determined. There is no need to type more than we need.

--- a/functions/@types/firebase-tools/index.d.ts
+++ b/functions/@types/firebase-tools/index.d.ts
@@ -1,0 +1,24 @@
+declare module "firebase-tools" {
+  export namespace firestore {
+    // inferred from https://github.com/firebase/firebase-tools/blob/v5.1.1/commands/firestore-delete.js#L72
+    function _delete(
+      path: string,
+      options?: DeleteOptionsWhenPathProvided
+    ): Promise<void>;
+
+    function _delete(
+      path: undefined,
+      options: { allCollections: true } & DeleteOptionsWhenPathProvided
+    ): Promise<void>;
+
+    type DeleteOptionsWhenPathProvided = {
+      project: string;
+      allCollections?: false; // makes no sense to have this be true if a path is provided
+      recursive?: boolean;
+      shallow?: boolean;
+      yes: true; // makes no sense to have this not be true when calling from code (i.e. not from the CLI)
+    };
+
+    export { _delete as delete };
+  }
+}

--- a/functions/@types/firebase-tools/index.d.ts
+++ b/functions/@types/firebase-tools/index.d.ts
@@ -1,17 +1,20 @@
 declare module "firebase-tools" {
   export namespace firestore {
-    // inferred from https://github.com/firebase/firebase-tools/blob/v5.1.1/commands/firestore-delete.js#L72
+    // types inferred from https://github.com/firebase/firebase-tools/blob/v5.1.1/commands/firestore-delete.js#L72
+
+    // overload that deletes only one collection
     function _delete(
       path: string,
-      options?: DeleteOptionsWhenPathProvided
+      options?: DeleteOptions
     ): Promise<void>;
 
+    // overload that deletes all collections
     function _delete(
       path: undefined,
-      options: { allCollections: true } & DeleteOptionsWhenPathProvided
+      options: { allCollections: true } & DeleteOptions
     ): Promise<void>;
 
-    type DeleteOptionsWhenPathProvided = {
+    type DeleteOptions = {
       project: string;
       allCollections?: false; // makes no sense to have this be true if a path is provided
       recursive?: boolean;
@@ -19,6 +22,8 @@ declare module "firebase-tools" {
       yes: true; // makes no sense to have this not be true when calling from code (i.e. not from the CLI)
     };
 
+    // this is required because TypeScript type declarations do not support
+    // keywords as function names
     export { _delete as delete };
   }
 }

--- a/functions/@types/firebase-tools/index.d.ts
+++ b/functions/@types/firebase-tools/index.d.ts
@@ -3,10 +3,7 @@ declare module "firebase-tools" {
     // types inferred from https://github.com/firebase/firebase-tools/blob/v5.1.1/commands/firestore-delete.js#L72
 
     // overload that deletes only one collection
-    function _delete(
-      path: string,
-      options?: DeleteOptions
-    ): Promise<void>;
+    function _delete(path: string, options?: DeleteOptions): Promise<void>;
 
     // overload that deletes all collections
     function _delete(

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -4444,14 +4444,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4466,20 +4464,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4596,8 +4591,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4609,7 +4603,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4624,7 +4617,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4736,8 +4728,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4870,7 +4861,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6947,11 +6937,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
-    },
-    "lodash.partition": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
-      "integrity": "sha1-o45GtzRp4EILDaEhLmbUFL42S6Q="
     },
     "lodash.values": {
       "version": "2.4.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -14,7 +14,6 @@
     "firebase-admin": "5.13.1",
     "firebase-functions": "2.0.2",
     "firebase-tools": "^5.1.1",
-    "lodash.partition": "4.6.0",
     "mailgun-js": "0.20.0",
     "node-fetch": "2.2.0"
   },

--- a/functions/src/compute-statistics.ts
+++ b/functions/src/compute-statistics.ts
@@ -15,6 +15,7 @@ export const computeStatistics = functions.https.onRequest(
     if (!computeStatisticsConfigs.enabled) {
       return;
     }
+
     const authorizationHeader = req.get("Authorization") || "";
     const keyIsCorrect =
       authorizationHeader === `Bearer ${computeStatisticsConfigs.key}`;
@@ -24,7 +25,7 @@ export const computeStatistics = functions.https.onRequest(
     }
 
     await firebaseTools.firestore.delete("stats", {
-      project: process.env.GCLOUD_PROJECT!,
+      project: config.service_account.project_id,
       recursive: true,
       yes: true
     });

--- a/functions/src/compute-statistics.ts
+++ b/functions/src/compute-statistics.ts
@@ -24,7 +24,7 @@ export const computeStatistics = functions.https.onRequest(
     }
 
     await firebaseTools.firestore.delete("stats", {
-      project: process.env.GCLOUD_PROJECT,
+      project: process.env.GCLOUD_PROJECT!,
       recursive: true,
       yes: true
     });

--- a/functions/src/exchange-token.ts
+++ b/functions/src/exchange-token.ts
@@ -26,7 +26,7 @@ interface RequestPayload {
   accessToken?: string;
 }
 
-const errorResponse = message => ({ error: { message } });
+const errorResponse = (message: string) => ({ error: { message } });
 
 /**
  * Cannot use functions.https.onCall here because this function is called

--- a/functions/src/save-ticks.ts
+++ b/functions/src/save-ticks.ts
@@ -6,7 +6,7 @@ export interface Tick {
   emittedAt: firestore.Timestamp;
 }
 
-const pubSubToFirestoreFunction = topic =>
+const pubSubToFirestoreFunction = (topic: string) =>
   functions.pubsub.topic(topic).onPublish(event =>
     firestore()
       .collection(topic)

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -7,10 +7,7 @@
     "sourceMap": true,
     "target": "es6",
     "strict": true,
-    // noImplicitAny is not compatible with firebase-functions@^1.0.0
-    // if npm run build succeeds without this line then it can be safely removed
-    // see also: https://github.com/firebase/firebase-functions/issues/213
-    "noImplicitAny": false
+    "typeRoots": ["@types"]
   },
   "compileOnSave": true,
   "include": ["src"]


### PR DESCRIPTION
We had to switch the `noImplicitAny` TypeScript compiler option off when [upgrading to `firebase-functions@1.0.0`](https://github.com/Zenika/humeur-du-mois-2018/commit/65a61084f369915c588dc896bec62a443a67d77a#diff-dc8de0a814a0e019ed6c1deb12c75cfeR13) because it is not compatible with it (see [this issue](https://github.com/firebase/firebase-functions/issues/213)). However since then `firebase-functions`  has been patched, and we've upgraded so we should be able to turn the option back on.

When I tried to turn it on, the compiler detected a few places where the code was relying on some legitimate implicit anys. But it did also complain about 2 other packages that were not compatible with the option, because they were lacking types. These packages are `lodash.partition` and `firebase-tools`.

I chose to remove `lodash.partition` because I felt it was not pulling its weight, as suggested by @brunosabot  [here](https://github.com/Zenika/humeur-du-mois-2018/pull/12#issuecomment-418684338).

On the other hand, we really need `firebase-tools`, but this time instead of turning `noImplicitAny` off because of it, I took the time to study how it can be left on while using packages without types. It turns out it is possible to write your own type declarations for a module installed from npm, though it took a bit of trial and error to get there. I've documented what works in `@types/README.md`, and I've written a type declaration for the one and only function that we use from the package.