### PR TITLE
remove node version locking in function emulator scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "scripts": {
     "start": "run-p serve functions:build:watch ui:build:watch",
     "start:shell": "run-p functions:shell functions:build:watch ui:build:watch",
-    "serve": "npx node@6.11.5 ./node_modules/firebase-tools/bin/firebase serve",
-    "functions:shell": "npx node@6.11.5 ./node_modules/firebase-tools/bin/firebase functions:shell",
+    "serve": "npx node@6.11.5 ./node_modules/firebase-tools/lib/bin/firebase serve",
+    "functions:shell": "npx node@6.11.5 ./node_modules/firebase-tools/Lib/bin/firebase functions:shell",
     "deploy": "npm run firebase deploy",
     "firebase": "firebase",
     "watch": "run-p functions:build:watch ui:build:watch",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "scripts": {
     "start": "run-p serve functions:build:watch ui:build:watch",
     "start:shell": "run-p functions:shell functions:build:watch ui:build:watch",
-    "serve": "npx node@6.11.5 ./node_modules/firebase-tools/lib/bin/firebase serve",
-    "functions:shell": "npx node@6.11.5 ./node_modules/firebase-tools/Lib/bin/firebase functions:shell",
+    "serve": "firebase serve",
+    "functions:shell": "firebase functions:shell",
     "deploy": "npm run firebase deploy",
     "firebase": "firebase",
     "watch": "run-p functions:build:watch ui:build:watch",


### PR DESCRIPTION
bf050740ee1b69a236ea1233dda9e8cd17801037 upgraded the firebase-tools version, which broke some npm script because the path to the cli js file has changed.

I've decided to remove the dependency on the full path to the cli js file. I've reverted to using the cli as it meant to be used, without forcing the Node.js version.

I had to introduce the version locking to make the function emulator work on Windows, but it does not seem to be required anymore, it works fine without it.