### PR TITLE
:sparkles: support multiple alibeez keys

### DIFF
--- a/functions/src/config.ts
+++ b/functions/src/config.ts
@@ -187,9 +187,13 @@ export interface FeaturesConfig {
   emails: EmailsConfig;
 }
 
+export interface AlibeezKeysConfig {
+  [key: string]: string;
+}
+
 export interface AlibeezConfig {
   url: string;
-  key: string;
+  keys: AlibeezKeysConfig;
 }
 
 export interface ServiceAccountConfig {

--- a/functions/src/import-employees-from-alibeez-daily.ts
+++ b/functions/src/import-employees-from-alibeez-daily.ts
@@ -11,5 +11,10 @@ export const importEmployeesFromAlibeezDaily = functions.firestore
       console.info("feature is disabled; aborting");
       return;
     }
-    await importEmployeesFromAlibeez(config.alibeez);
+    for (const key of Object.values(config.alibeez.keys)) {
+      await importEmployeesFromAlibeez({
+        url: config.alibeez.url,
+        key
+      });
+    }
   });

--- a/functions/src/import-employees-from-alibeez.ts
+++ b/functions/src/import-employees-from-alibeez.ts
@@ -50,7 +50,9 @@ const hasValidEmail = (employee: AlibeezEmployee) =>
   employee.zenikaEmail && employee.zenikaEmail.endsWith("@zenika.com");
 const hasNoValidEmail = (employee: AlibeezEmployee) => !hasValidEmail(employee);
 
-export const importEmployeesFromAlibeez = async (config: AlibeezImportConfig) => {
+export const importEmployeesFromAlibeez = async (
+  config: AlibeezImportConfig
+) => {
   const requestRef = await firebase
     .firestore()
     .collection("alibeez-requests")

--- a/functions/src/import-employees-from-alibeez.ts
+++ b/functions/src/import-employees-from-alibeez.ts
@@ -1,12 +1,16 @@
 import * as firebase from "firebase-admin";
 import fetch from "node-fetch";
-import { AlibeezConfig } from "./config";
 
 interface AlibeezEmployee {
   zenikaEmail: string;
   fullName: string | null;
   operationalManagerShortUsername: string | null;
   geographicalAgency: string | null;
+}
+
+interface AlibeezImportConfig {
+  url: string;
+  key: string;
 }
 
 export interface Employee {
@@ -46,7 +50,7 @@ const hasValidEmail = (employee: AlibeezEmployee) =>
   employee.zenikaEmail && employee.zenikaEmail.endsWith("@zenika.com");
 const hasNoValidEmail = (employee: AlibeezEmployee) => !hasValidEmail(employee);
 
-export const importEmployeesFromAlibeez = async (config: AlibeezConfig) => {
+export const importEmployeesFromAlibeez = async (config: AlibeezImportConfig) => {
   const requestRef = await firebase
     .firestore()
     .collection("alibeez-requests")


### PR DESCRIPTION
This makes it possible to support employees from multiple countries. To get employees from multiple countries in Alibeez, one request per country is required. The URL to Alibeez does not change but the key changes. One key per country. The code supports an arbitrary number of keys.