### PR TITLE
:loud_sound: log ignored votes when importing

### DIFF
--- a/functions/src/import-votes.ts
+++ b/functions/src/import-votes.ts
@@ -16,6 +16,10 @@ const fromJSONtoVote = (supposedlyValidVotes: any) => {
       supposedlyValidVote.campaign &&
       supposedlyValidVote.agency
   );
+  console.info(
+    `ignored ${supposedlyValidVotes.votes.length -
+      validVotes.length} votes because they did not match the expected schema`
+  );
   return validVotes;
 };
 


### PR DESCRIPTION
Useful when one's trying to import data but nothing appears in the db because there is a problem with schema of the data to import.