### PR TITLE
:recycle: make compute statistics only respond when all documents have been written

### DIFF
--- a/functions/src/compute-statistics.ts
+++ b/functions/src/compute-statistics.ts
@@ -50,12 +50,17 @@ export const computeStatistics = functions.https.onRequest(
         {} as { [key: string]: any }
       );
 
-    Object.keys(statisticsData).forEach(key => {
+    // we should really batch this because this could
+    // represent hundreds of documents
+    // eg for 5 years and 10 agencies -> 660 documents
+    for (const key of Object.keys(statisticsData)) {
+      console.log(`writing ${key}`);
       const row = statisticsData[key];
-      db.doc(key)
+      await db
+        .doc(key)
         .set(row)
         .catch(err => console.error(err));
-    });
+    }
 
     res.sendStatus(200);
   }

--- a/functions/src/compute-statistics.ts
+++ b/functions/src/compute-statistics.ts
@@ -53,14 +53,16 @@ export const computeStatistics = functions.https.onRequest(
     // we should really batch this because this could
     // represent hundreds of documents
     // eg for 5 years and 10 agencies -> 660 documents
-    for (const key of Object.keys(statisticsData)) {
-      console.log(`writing ${key}`);
-      const row = statisticsData[key];
-      await db
-        .doc(key)
-        .set(row)
-        .catch(err => console.error(err));
-    }
+    await Promise.all(
+      Object.keys(statisticsData).map(key => {
+        console.log(`writing ${key}`);
+        const row = statisticsData[key];
+        return db
+          .doc(key)
+          .set(row)
+          .catch(err => console.error(err));
+      })
+    );
 
     res.sendStatus(200);
   }


### PR DESCRIPTION
The current version of the function makes it responds "OK" before everything is written to the database. This new version responds OK only when everything has been written.