### PR TITLE
🛠🍎 fix prettier script on macos

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch": "run-p functions:build:watch ui:build:watch",
     "functions:build:watch": "npm --prefix functions run build:watch",
     "ui:build:watch": "npm --prefix ui run build:watch",
-    "prettier": "prettier .circleci/config.yml  'functions/{**/,}*.{ts,json}' 'ui/{**/,}*.{ts,json,html}'",
+    "prettier": "prettier .circleci/config.yml \"functions/{**/,}*.{ts,json}\" \"ui/{**/,}*.{ts,json,html}\"",
     "prettier:check": "npm run prettier -- --check",
     "prettier:write": "npm run prettier -- --write",
     "test": "ava ./deployment/check-config/**.test.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch": "run-p functions:build:watch ui:build:watch",
     "functions:build:watch": "npm --prefix functions run build:watch",
     "ui:build:watch": "npm --prefix ui run build:watch",
-    "prettier": "prettier .circleci/config.yml  functions/{**/,}*.{ts,json} ui/{**/,}*.{ts,json,html}",
+    "prettier": "prettier .circleci/config.yml  'functions/{**/,}*.{ts,json}' 'ui/{**/,}*.{ts,json,html}'",
     "prettier:check": "npm run prettier -- --check",
     "prettier:write": "npm run prettier -- --write",
     "test": "ava ./deployment/check-config/**.test.js",


### PR DESCRIPTION
This is a recurrent problem I often see since I switched to a Macbook, without the `'` prettier won't find some of the files and throw an error