### PR TITLE
🐛 fix start-of-campaign reminder recipients

### DIFF
--- a/functions/src/send-reminders.ts
+++ b/functions/src/send-reminders.ts
@@ -108,7 +108,6 @@ export const sendCampaignStartsReminder = functions.firestore
     const message = {
       from: config.features.reminders.voting_campaign_starts.sender,
       to: config.features.reminders.voting_campaign_starts.recipient,
-      bcc: await computeBccString(db, campaign.id),
       subject: `Humeur du mois is open for ${monthLongName}!`,
       html: `
         <p>Hi,</p>


### PR DESCRIPTION
#135 applied its change to start-of-campaign reminders by error. Only end-of-campaign reminders should be sent only to employees who have not voted.