### PR TITLE
🐛 fix config not accepting optional recipient for end-of-campaign reminders

### DIFF
--- a/functions/src/config.ts
+++ b/functions/src/config.ts
@@ -116,7 +116,7 @@ export interface VotingCampaignEndsReminderConfig {
   /**
    * Mailing list to which to send the reminder emails.
    */
-  recipient: string;
+  recipient?: string;
   /**
    * When to send the reminder, in number of days before the end of the
    * campaign.

--- a/functions/src/send-reminders.ts
+++ b/functions/src/send-reminders.ts
@@ -180,7 +180,7 @@ export const sendCampaignEndsReminder = functions.firestore
 
     const message = {
       from: config.features.reminders.voting_campaign_ends.sender,
-      to: config.features.reminders.voting_campaign_ends.recipient,
+      to: config.features.reminders.voting_campaign_ends.recipient || [],
       bcc: await computeBccString(db, campaign.id),
       subject: `Humeur du mois is about to close for ${monthLongName}!`,
       html: `


### PR DESCRIPTION
Should have been done in #135 