### PR TITLE
📦 include auth0 in the js bundle

### DIFF
--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -5,11 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Humeur du mois</title>
 
-    <script
-      defer
-      src="https://cdn.auth0.com/js/auth0/9.7.3/auth0.min.js"
-    ></script>
-
     <!-- update the version number as needed -->
     <script defer src="/__/firebase/5.3.1/firebase-app.js"></script>
     <!-- include only the Firebase features as you need -->

--- a/ui/webpack.config.ts
+++ b/ui/webpack.config.ts
@@ -20,7 +20,6 @@ export default (): webpack.Configuration => ({
   },
   resolve: { extensions: [".js", ".ts"] },
   externals: {
-    "auth0-js": "auth0",
     "firebase/app": "firebase"
   },
   plugins: [


### PR DESCRIPTION
Close #80 

Remove auth0 from the Webpack "externals" so that it is included in the js bundle.

FYI the minified auth0 script weights 148ko so the final bundle is a lot bigger than before. But I have seen that with gzip compression it falls down to ~36ko and the production app uses brotli compression so it should not be too big.