### PR TITLE
🐛 fix the link of the webapp in the reminder email

### DIFF
--- a/functions/src/send-reminders.ts
+++ b/functions/src/send-reminders.ts
@@ -113,7 +113,7 @@ export const sendCampaignStartsReminder = functions.firestore
         <p>Hi,</p>
         <p>
           Tell us how it's been for you this past month!
-          Go to ${linkToApp}.
+          Go to <a href="${linkToApp}">${linkToApp}</a>.
         </p>
         <p>See you soon!</p>
         `


### PR DESCRIPTION
Close #103 

I don't know how to test it, but I think using an anchor tag for the link will fix the issue. Indeed, in Thunderbird the reminder for the closing of the vote is correctly displayed, and it has the anchor tag.