### PR TITLE
⚡️ Improve logging time

### DIFF
--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -44,7 +44,7 @@
         </button>
       </div>
       <div class="navbar__about">
-        <button type="button" class="navbar__button hidden" id="logoutButton">
+        <button type="button" class="navbar__button" id="logoutButton">
           <svg viewBox="0 0 24 24" class="navbar__button-emoji">
             <path
               d="M10.09 15.59L11.5 17l5-5-5-5-1.41 1.41L12.67 11H3v2h9.67l-2.58 2.59zM19 3H5c-1.11 0-2 .9-2 2v4h2V5h14v14H5v-4H3v4c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
@@ -120,16 +120,18 @@
         </div>
         <h2>A little comment?</h2>
         <textarea class="textarea" id="comment" rows="4"></textarea>
-        <div id="managerNotice" class="managerNotice hidden">
-          The result will be sent to <span id="managerName"></span>
-        </div>
-        <div id="errorDisplay" class="errorDisplay" hidden>
-          Please, click on one mood
-        </div>
-        <div class="button-vote-wrapper">
-          <button id="buttonVote" type="button" class="button--small">
-            Vote
-          </button>
+        <div id="sendingSection" class="hidden">
+          <div id="managerNotice" class="managerNotice">
+            The result will be sent to <span id="managerName"></span>
+          </div>
+          <div id="errorDisplay" class="errorDisplay" hidden>
+            Please, click on one mood
+          </div>
+          <div class="button-vote-wrapper">
+            <button id="buttonVote" type="button" class="button--small">
+              Vote
+            </button>
+          </div>
         </div>
       </div>
       <div id="displayStats" class="page hidden">

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -120,6 +120,7 @@
         </div>
         <h2>A little comment?</h2>
         <textarea class="textarea" id="comment" rows="4"></textarea>
+        <div id="sendingSectionLoader"></div>
         <div id="sendingSection" class="hidden">
           <div id="managerNotice" class="managerNotice">
             The result will be sent to <span id="managerName"></span>

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -142,7 +142,9 @@
             <select id="agencySelector"> </select>
           </div>
         </h1>
-        <h2 id="statsTitle" class="hidden">Stats for agency:&nbsp;<span id="agencyName"></span></h2>
+        <h2 id="statsTitle" class="hidden">
+          Stats for agency:&nbsp;<span id="agencyName"></span>
+        </h2>
         <div id="statsTab"></div>
       </div>
       <div id="recordingPage" class="page hidden">

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -142,7 +142,7 @@
             <select id="agencySelector"> </select>
           </div>
         </h1>
-        <h2 id="statsTitle">Stats for agency: <span id="agencyName"></span></h2>
+        <h2 id="statsTitle">Stats for agency:&nbsp;<span id="agencyName"></span></h2>
         <div id="statsTab"></div>
       </div>
       <div id="recordingPage" class="page hidden">

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -142,7 +142,7 @@
             <select id="agencySelector"> </select>
           </div>
         </h1>
-        <h2 id="statsTitle">Stats for agency:&nbsp;<span id="agencyName"></span></h2>
+        <h2 id="statsTitle" class="hidden">Stats for agency:&nbsp;<span id="agencyName"></span></h2>
         <div id="statsTab"></div>
       </div>
       <div id="recordingPage" class="page hidden">

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -96,6 +96,7 @@ window.addEventListener("load", async function () {
     statsTitle.style.display = "none";
     statsTab.innerHTML = statsLoader;
     voteData = await retrieveStatsData(agency);
+    await fillAgenciesList();
     statsTitle.style.display = "";
     displayStatsData(voteData, agency);
   };
@@ -317,9 +318,6 @@ window.addEventListener("load", async function () {
     // 5 - Display the sending section (vote button + manager email)
     hide(sendingSectionLoader);
     show(sendingSection);
-
-    // 6 - Fetch the list of agencies
-    await fillAgenciesList();
   } catch (err) {
     errorOut(err);
     return;

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -51,6 +51,7 @@ window.addEventListener("load", async function () {
   const userIdElement = document.getElementById("userId")!;
   const userEmail = document.getElementById("userEmail")!;
   const sendingSection = document.getElementById("sendingSection")!;
+  const sendingSectionLoader = document.getElementById("sendingSectionLoader")!;
   const managerName = document.getElementById("managerName")!;
   const hideClass = "hidden";
 
@@ -58,7 +59,6 @@ window.addEventListener("load", async function () {
   let selectedAgency = "";
 
   const htmlLoader = `
-  <h2>
     <div class="loader">
       <svg class="circular" viewBox="25 25 50 50">
         <circle
@@ -71,9 +71,11 @@ window.addEventListener("load", async function () {
           strokeMiterlimit="10"
         />
       </svg>
-    </div>
-    Hold on, we're retrieving the data you requested ...
-  </h2>`;
+    </div>`;
+
+  const statsLoader = `<div class="loading-message">${htmlLoader} Hold on, we're retrieving the data you requested ...</div>`;
+
+  sendingSectionLoader.innerHTML = htmlLoader;
 
   const show = (element: HTMLElement) => {
     element.classList.remove(hideClass);
@@ -92,7 +94,7 @@ window.addEventListener("load", async function () {
   const displayStatsPage = async (agency?: string) => {
     changePageTo(statsPage);
     statsTitle.style.display = "none";
-    statsTab.innerHTML = htmlLoader;
+    statsTab.innerHTML = statsLoader;
     voteData = await retrieveStatsData(agency);
     statsTitle.style.display = "";
     displayStatsData(voteData, agency);
@@ -283,7 +285,6 @@ window.addEventListener("load", async function () {
     if (employee.managerEmail) {
       managerName.innerText = employee.managerEmail;
     }
-    show(sendingSection);
   };
 
   try {
@@ -313,7 +314,11 @@ window.addEventListener("load", async function () {
       signOutAuth0(webAuth);
     };
 
-    // 5 - Fetch the list of agencies
+    // 5 - Display the sending section (vote button + manager email)
+    hide(sendingSectionLoader);
+    show(sendingSection);
+
+    // 6 - Fetch the list of agencies
     await fillAgenciesList();
   } catch (err) {
     errorOut(err);

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -76,7 +76,6 @@ window.addEventListener("load", async function () {
   const statsLoader = `<div class="loading-message">${htmlLoader} Hold on, we're retrieving the data you requested ...</div>`;
 
   sendingSectionLoader.innerHTML = htmlLoader;
-  statsTitle.style.display = "none";
   statsTab.innerHTML = statsLoader;
 
   const show = (element: HTMLElement) => {
@@ -326,7 +325,7 @@ window.addEventListener("load", async function () {
 
     renderInitialStatsPage()
       .then(() => {
-        statsTitle.style.display = "";
+        show(statsTitle);
       })
       .catch(errorOut);
   } catch (err) {

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -302,13 +302,13 @@ window.addEventListener("load", async function () {
     userIdElement.innerText = session.user.email;
     displayHomePage();
     initVoteButtonsEventHandlers();
+    initStatsButtonsEventHandlers();
 
     // 3 - Firebase authentication, fetch the campaign and employee data
     await authenticateFirebase(session);
     await initCampaignAndEmployeeData(session.user.email);
 
-    // 4 - Now that the user is fully logged in, they can go on the stats page and logout
-    initStatsButtonsEventHandlers();
+    // 4 - Now that the user is fully logged in, they can logout
     logoutButton.onclick = async () => {
       await signOutFirebase();
       signOutAuth0(webAuth);

--- a/ui/src/styles/style.css
+++ b/ui/src/styles/style.css
@@ -53,7 +53,8 @@ button {
   padding: 0 32px;
 }
 
-.page h2 {
+.page h2,
+.loading-message {
   align-items: center;
   color: rgba(0, 0, 0, 0.6);
   display: flex;
@@ -232,6 +233,13 @@ tr:hover td {
   animation: dash 1.5s ease-in-out infinite,
     colorRotation 6s ease-in-out infinite;
   stroke-linecap: round;
+}
+
+#sendingSectionLoader:not(.hidden) {
+  height: 90px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 @keyframes rotate {

--- a/ui/src/styles/style.css
+++ b/ui/src/styles/style.css
@@ -188,7 +188,9 @@ tr:hover td {
 }
 
 .hidden {
-  display: none;
+  /* !important required here to ensure all .hidden are hidden ignoring all
+  other rules of higher specifify */
+  display: none !important;
 }
 
 .errorDisplay {


### PR DESCRIPTION
Close #41 

I made quite a few changes, I hope it is not too much for one PR. But the logging time (at least  perceived) is much shorter. 

Here is what I did:

- remove the call to the auth0 API `authenticationClient.getProfile()` in the `exchangeToken` function, which was not necessary since all we got from it was the user email, which we already have from the auth0 authentication. The call to this function was one of the longest so I think we can save several seconds on the production app just by removing it.
- change the order of some operations: use optimistic UI to display the main content right after the auth0 authentication, and display the rest after the Firebase authentication. Also fetch the list of agencies at the very end since it is in the second page so we don't need it straight away.
- display a little loader during the Firebase authentication when the main content is already there, to let the user know that there is still something happening in the background so they are not frustrated if an error message shows up (like campaign closed)